### PR TITLE
Fix Readme Commands URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > **Documentation: [Click here](https://byte.str1ke.codes)**
 
-> **Commands: [Click here](hhttps://byte.str1ke.codes/commands)**
+> **Commands: [Click here](https://byte.str1ke.codes/commands)**
 
 ## Credits
 


### PR DESCRIPTION
Fix typo in Readme URL that prevents clickable link from being created.